### PR TITLE
Fix warning: Add missing version to maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.3.1</version>
         <configuration>
           <author>true</author>
           <source>1.8</source>


### PR DESCRIPTION
Description:

This PR addresses a Maven warning encountered during build:
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing.
Explicitly specifying the plugin version ensures consistent and stable builds across environments and prevents issues with future Maven versions.

Fixes: #3 