### PR TITLE
feat: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly" # Check for updates weekly
+    open-pull-requests-limit: 10 # Limit the number of open PRs to avoid noise
+    target-branch: "master"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+


### PR DESCRIPTION
**Closes #5**

Implements an automated dependency management tool by adding the necessary **.github/dependabot.yml** configuration file.

This configuration enables Dependabot to monitor the **Maven** ecosystem weekly and automatically generate Pull Requests for available dependency updates.

This action addresses and resolves the Dependency-Update-Tool (0/10) metric.