### PR TITLE
feat: Add CI workflow for automated Maven build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,40 @@ name: CI Build and Test
 
 permissions:
   contents: read
+  actions: read
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'maven'
+      - name: Set up JDK 17 and Maven Cache
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
 
-    - name: Build and Run Tests
-      run: mvn -B clean verify
+      - name: Install Groovy
+        run: sudo apt-get update && sudo apt-get install -y groovy
+
+      - name: 1. Clone and Install apis-bom
+        run: |
+          git clone https://github.com/hyphae/apis-bom.git ../apis-bom
+          mvn -B -f ../apis-bom/pom.xml clean install -DskipTests=true -Dmaven.test.failure.ignore=true
+
+      - name: 2. Clone and Install apis-common
+        run: |
+          git clone https://github.com/hyphae/apis-common.git ../apis-common
+          mvn -B -f ../apis-common/pom.xml clean install -DskipTests=true -Dmaven.test.failure.ignore=true
+
+      - name: 3. Build and Test apis-main
+        run: mvn -B clean verify


### PR DESCRIPTION
*Closes #11*

Implements the Continuous Integration (CI) test execution required by OpenSSF Scorecard. This is done by adding the workflow file .github/workflows/ci.yml.

The workflow is configured to run on all pushes and pull requests to the main branch, executing mvn clean verify to build the project and run the test suite.

This action addresses and resolves the CI-Tests (0/10) metric.