### PR TITLE
fix: update logging to SLF4J for Vert.x 3.4.x compatibility

### DIFF
--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/LogReceiver.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/LogReceiver.java
@@ -7,8 +7,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -179,7 +179,7 @@ public class LogReceiver extends AbstractVerticle {
 				}
 			}
 		} catch (SocketException e) {
-			log.error(e);
+			log.error("Socket exception while getting network interface", e);
 			completionHandler.handle(Future.failedFuture(e));
 			return;
 		}

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/LogReceiver.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/LogReceiver.java
@@ -122,9 +122,9 @@ public class LogReceiver extends AbstractVerticle {
 					if (printToStdout) System.out.println("[" + packet.sender() + "] " + String.valueOf(packet.data()).trim());
 				}).exceptionHandler(t -> {
 					log.error("exceptionHandler : " + t);
-				}).listen(port, listenAddress, resListen -> {
+				}).listen(port, listenAddress).onComplete(resListen -> {
 					if (resListen.succeeded()) {
-						socket.listenMulticastGroup(multicastGroupAddress, networkInterfaceName, null, resListenMulticastGroup -> {
+						socket.listenMulticastGroup(multicastGroupAddress, networkInterfaceName, null).onComplete(resListenMulticastGroup -> {
 							if (resListenMulticastGroup.succeeded()) {
 								if (log.isInfoEnabled()) log.info("log receive multicast service started on group address : " + multicastGroupAddress + ", port : " + port);
 								completionHandler.handle(Future.succeededFuture());

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/ApisVertxLogParser.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/ApisVertxLogParser.java
@@ -3,8 +3,9 @@ package jp.co.sony.csl.dcoes.apis.tools.log.util;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Parses received APIS log.

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/MongoDbWriter.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/MongoDbWriter.java
@@ -198,7 +198,7 @@ public class MongoDbWriter {
 	 * @param completionHandler the completion handler
 	 */
 	public static void write_(JsonObject value, Handler<AsyncResult<Void>> completionHandler) {
-		client_.insert(collection_, value, res -> {
+		client_.insert(collection_, value).onComplete(res -> {
 			if (res.succeeded()) {
 				completionHandler.handle(Future.succeededFuture());
 			} else {

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/MongoDbWriter.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/MongoDbWriter.java
@@ -6,8 +6,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.datagram.DatagramPacket;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.vertx.ext.mongo.MongoClient;
 
 import java.util.logging.Level;
@@ -67,7 +67,7 @@ public class MongoDbWriter {
 			try {
 				level_ = Level.parse(VertxConfig.config.getString(DEFAULT_LEVEL, "mongoDbWriter", "level"));
 			} catch (Exception e) {
-				log.error(e);
+				log.error("Failed to process data", e);
 				completionHandler.handle(Future.failedFuture(e));
 				return;
 			}
@@ -122,7 +122,7 @@ public class MongoDbWriter {
 				level = level_(json);
 				loggername = json.getString("loggername");
 			} catch (Exception e) {
-				log.error(e);
+				log.error("Error in MongoDB operation", e);
 				completionHandler.handle(Future.failedFuture(e));
 				return;
 			}

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/Starter.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/tools/log/util/Starter.java
@@ -26,7 +26,7 @@ public class Starter extends AbstractStarter {
 	 * 起動時に {@link AbstractStarter#start(Future)} から呼び出される.
 	 */
 	@Override protected void doStart(Handler<AsyncResult<Void>> completionHandler) {
-		vertx.deployVerticle(new LogReceiver(), resLogReceiver -> {
+		vertx.deployVerticle(new LogReceiver()).onComplete(resLogReceiver -> {
 			if (resLogReceiver.succeeded()) {
 				completionHandler.handle(Future.succeededFuture());
 			} else {


### PR DESCRIPTION
## Problem
CodeQL build failing due to Vert.x 3.4.x API incompatibilities:
- `io.vertx.core.logging` package removed in Vert.x 3.4.x
- SLF4J is now the standard logger
- Error logging methods expect String message + exception
- Async methods now use `.onComplete()` pattern instead of callbacks

## Solution
- Replaced all `io.vertx.core.logging` imports with `org.slf4j`
- Fixed error logging to use proper SLF4J format: `log.error("message", e)`
- Updated async methods to use `.onComplete()` pattern:
  - `listen()` and `listenMulticastGroup()` in `LogReceiver.java`
  - `insert()` in `MongoDbWriter.java`
  - `deployVerticle()` in `Starter.java`
- Updated files:
  - `LogReceiver.java`
  - `ApisVertxLogParser.java`
  - `MongoDbWriter.java`
  - `Starter.java`

## Testing
✅ `mvn clean compile` passes  
✅ `mvn test` passes (all 3 tests)  
✅ `mvn verify` passes

## Related
Fixes #22