### PR TITLE
chore: update Java version from 8 to 11 and upgrade maven-compiler-plugin to 3.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
         <!-- We specify the Maven compiler plugin as we need to set it to Java 1.8 -->
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.11.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>11</source>
+            <target>11</target>
           </configuration>
         </plugin>
       </plugins>
@@ -138,7 +138,7 @@
         <version>3.3.1</version>
         <configuration>
           <author>true</author>
-          <source>1.8</source>
+          <source>11</source>
           <show>private</show>
           <encoding>UTF-8</encoding>
           <charset>UTF-8</charset>


### PR DESCRIPTION
## What this PR does
- Updates Java source/target from 8 → 11
- Updates maven-compiler-plugin from 3.1 → 3.11.0
- Vert.x 3.9.15 remains unchanged (already correct)

## Why
- Standardize Java version across repositories
- Modernize build tooling
- Align with team's stable-vertx-3.9 branch

## Testing
✅ `mvn clean compile` passes
✅ `mvn test` passes (3/3 tests)
✅ Vert.x 3.9.15 confirmed

## DCO
✅ Signed-off-by included